### PR TITLE
[SmartHotel.Clients] MSBuild settings to improve build performance

### DIFF
--- a/Source/SmartHotel.Clients/SmartHotel.Clients/SmartHotel.Clients.csproj
+++ b/Source/SmartHotel.Clients/SmartHotel.Clients/SmartHotel.Clients.csproj
@@ -5,13 +5,10 @@
     <AssemblyName>SmartHotel.Clients.Core</AssemblyName>
     <RootNamespace>SmartHotel.Clients.Core</RootNamespace>
     <Configurations>Debug;Release;UI Test;UI-Test</Configurations>
+    <ProduceReferenceAssembly>True</ProduceReferenceAssembly>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='UI Test|AnyCPU'">
     <DefineConstants>TRACE;IS_UI_TEST;</DefineConstants>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugType>Full</DebugType>
-    <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
   <ItemGroup>
     <None Remove="Resources\GreetingMessage.txt" />


### PR DESCRIPTION
Context: https://devblogs.microsoft.com/xamarin/optimize-xamarin-android-builds/

Two things would help improve the build times of this sample:

1. Use `$(ProduceReferenceAssembly)`. This makes it so small code
   changes to C# or XAML don't cause the Android head project to
   rebuild. It will likely help other platforms as well.

2. Don't set `$(DebugType)` to `Full`. We want to use `Portable`,
   which is the default. Otherwise, we have to convert the symbols in
   Xamarin.Android to a format the Mono runtimes support. This would
   happen on every build where you changed C# code.

These changes should be low risk: not likely to break anything. We
already have the Xamarin templates using these settings.

## Results ##

Building the `SmartHotel.Client.Android.csproj` project on Windows
with Visual Studio 2019 16.5 Preview 2:

    Before: Time Elapsed 00:00:04.13
    After:  Time Elapsed 00:00:02.37

This was after making a XAML change.